### PR TITLE
corrected the package json file to fix docker bug

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   },
   "scripts": {
     "build": "tsc",
-    "start": "node --env-file=.env --inspect dist/app.js",
+    "start": "node --inspect dist/app.js",
     "prestart": "npm run build",
     "start:dev": "ts-node-dev --respawn --transpile-only --env-file=.env  --watch './src/**/*.ts' src/app.ts",
     "start:dev:win": "ts-node-dev --respawn --transpile-only --env-file=.env --watch './src/**/*.ts' src/app.ts",


### PR DESCRIPTION
@HarishGangula docker failed since package file is looking for .env file. Corrected that.

To run the image, run command should be pointing to a env file and as mentioned in the last PR, DB should be running in the server locally. 